### PR TITLE
handle methods from java.lang.Object

### DIFF
--- a/scarlet/src/test/java/com/tinder/scarlet/ScarletTest.kt
+++ b/scarlet/src/test/java/com/tinder/scarlet/ScarletTest.kt
@@ -114,7 +114,7 @@ internal class ScarletTest {
         val equalsSelf = exampleService.equals(exampleService)
 
         // Then
-        assert(equalsSelf) { "equals must be reflexive" }
+        assertThat(equalsSelf).describedAs("equals must be reflexive").isTrue()
     }
 
     @Test
@@ -129,7 +129,7 @@ internal class ScarletTest {
         val equalsOther = exampleService.equals(otherExampleService)
 
         // Then
-        assert(!equalsOther) { "should not equal other instance" }
+        assertThat(equalsOther).describedAs("should not equal other instance").isFalse()
     }
 
     @Suppress("UNUSED")

--- a/scarlet/src/test/java/com/tinder/scarlet/ScarletTest.kt
+++ b/scarlet/src/test/java/com/tinder/scarlet/ScarletTest.kt
@@ -12,6 +12,7 @@ import com.tinder.scarlet.internal.Service
 import com.tinder.scarlet.internal.utils.RuntimePlatform
 import com.tinder.scarlet.ws.Receive
 import com.tinder.scarlet.ws.Send
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.junit.MockitoJUnitRunner
@@ -71,6 +72,64 @@ internal class ScarletTest {
 
         // Then
         then(service).should().execute(ExampleService::class.java.getDeclaredMethod("receive"), emptyArray())
+    }
+
+    @Test
+    fun create_hashCode_shouldEqualServiceInstanceHashCode() {
+        // Given
+        val service = mock<Service>()
+        given(serviceFactory.create(ExampleService::class.java)).willReturn(service)
+        val exampleService = scarlet.create<ExampleService>()
+
+        // When
+        val hashCode = exampleService.hashCode()
+
+        // Then
+        assertThat(hashCode).isEqualTo(service.hashCode())
+    }
+
+    @Test
+    fun create_toString_shouldProduceCorrectValue() {
+        // Given
+        val service = mock<Service>()
+        given(serviceFactory.create(ExampleService::class.java)).willReturn(service)
+        val exampleService = scarlet.create<ExampleService>()
+
+        // When
+        val toString = exampleService.toString()
+
+        // Then
+        assertThat(toString)
+            .isEqualTo("Scarlet service implementation for com.tinder.scarlet.ScarletTest\$Companion\$ExampleService")
+    }
+
+    @Test
+    fun create_equals_shouldEqualSelf() {
+        // Given
+        val service = mock<Service>()
+        given(serviceFactory.create(ExampleService::class.java)).willReturn(service)
+        val exampleService = scarlet.create<ExampleService>()
+
+        // When
+        val equalsSelf = exampleService.equals(exampleService)
+
+        // Then
+        assert(equalsSelf) { "equals must be reflexive" }
+    }
+
+    @Test
+    fun create_equals_shouldNotEqualOther() {
+        // Given
+        val service = mock<Service>()
+        given(serviceFactory.create(ExampleService::class.java)).willReturn(service)
+        val exampleService = scarlet.create<ExampleService>()
+        val otherExampleService = scarlet.create<ExampleService>()
+
+        // When
+        val equalsOther = exampleService.equals(otherExampleService)
+
+        // Then
+        assert(!equalsOther) { "should not equal other instance" }
     }
 
     @Suppress("UNUSED")


### PR DESCRIPTION
This is to address #28.
The existing behaviour is
```
val service = scarlet.create<ServiceInterface>()
service.toString() // throws
service.hashCode() // throws
service.equals(service) // throws
```
The updated behaviour is
```
service.toString() == "Scarlet service implementation for foo.bar.ServiceInterface"
service.hashCode() // hashCode of the underlying com.tinder.scarlet.internal.Service object
service.equals(other) // compare with the proxy object - provides equals that is reflexive, symmetric, and transitive as well as consistent with hashCode
```
