### PR TITLE
Fix #22: Update Usage example on README.md to match current implement…

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Declare a WebSocket client using an interface:
 ~~~ kotlin
 interface GdaxService {
 	@Receive
-	fun observeOnConnectionOpenedEvent(): Flowable<WebSocket.Event.OnConnectionOpen<*>>
+	fun observeWebSocketEvent(): Flowable<WebSocket.Event>
 	@Send
 	fun sendSubscribe(subscribe: Subscribe)
 	@Receive
@@ -49,7 +49,8 @@ val BITCOIN_TICKER_SUBSCRIBE_MESSAGE = Subscribe(
     channels = listOf("ticker")
 )
 
-gdaxService.observeOnConnectionOpenedEvent()
+gdaxService.observeWebSocketEvent()
+    .filter { it is WebSocket.Event.OnConnectionOpened<*> }
     .subscribe({
         gdaxService.sendSubscribe(BITCOIN_TICKER_SUBSCRIBE_MESSAGE)
     })


### PR DESCRIPTION
Issue #22 was created because the example on README throw the following error:

` IllegalArgumentException: Method return type must not include a type variable or wildcard: io.reactivex.Flowable<com.tinder.scarlet.WebSocket$Event$OnConnectionOpened<?>>`

The people that contributed to the issue realised the code had a different implementation. Therefore here is the update example code. 