### PR TITLE
fix lifecycle if pass lifecycleOwner (Activity, Fragment) to Scarlet.…

### DIFF
--- a/scarlet-lifecycle-android/src/main/java/com/tinder/scarlet/lifecycle/android/LifecycleOwnerResumedLifecycle.kt
+++ b/scarlet-lifecycle-android/src/main/java/com/tinder/scarlet/lifecycle/android/LifecycleOwnerResumedLifecycle.kt
@@ -12,8 +12,8 @@ import com.tinder.scarlet.LifecycleState
 import com.tinder.scarlet.lifecycle.LifecycleRegistry
 
 internal class LifecycleOwnerResumedLifecycle(
-    private val lifecycleOwner: LifecycleOwner,
-    private val lifecycleRegistry: LifecycleRegistry
+        private val lifecycleOwner: LifecycleOwner,
+        private val lifecycleRegistry: LifecycleRegistry
 ) : Lifecycle by lifecycleRegistry {
 
     init {
@@ -34,6 +34,7 @@ internal class LifecycleOwnerResumedLifecycle(
         @OnLifecycleEvent(androidx.lifecycle.Lifecycle.Event.ON_DESTROY)
         fun onDestroy() {
             lifecycleRegistry.onComplete()
+            lifecycleOwner.lifecycle.removeObserver(this)
         }
     }
 }

--- a/scarlet-lifecycle-android/src/main/java/com/tinder/scarlet/lifecycle/android/LifecycleOwnerStartedLifecycle.kt
+++ b/scarlet-lifecycle-android/src/main/java/com/tinder/scarlet/lifecycle/android/LifecycleOwnerStartedLifecycle.kt
@@ -12,8 +12,8 @@ import com.tinder.scarlet.LifecycleState
 import com.tinder.scarlet.lifecycle.LifecycleRegistry
 
 internal class LifecycleOwnerStartedLifecycle(
-    private val lifecycleOwner: LifecycleOwner,
-    private val lifecycleRegistry: LifecycleRegistry
+        private val lifecycleOwner: LifecycleOwner,
+        private val lifecycleRegistry: LifecycleRegistry
 ) : Lifecycle by lifecycleRegistry {
 
     init {
@@ -34,6 +34,7 @@ internal class LifecycleOwnerStartedLifecycle(
         @OnLifecycleEvent(androidx.lifecycle.Lifecycle.Event.ON_DESTROY)
         fun onDestroy() {
             lifecycleRegistry.onComplete()
+            lifecycleOwner.lifecycle.removeObserver(this)
         }
     }
 }

--- a/scarlet/src/main/java/com/tinder/scarlet/lifecycle/LifecycleStateUtils.kt
+++ b/scarlet/src/main/java/com/tinder/scarlet/lifecycle/LifecycleStateUtils.kt
@@ -8,8 +8,11 @@ import com.tinder.scarlet.LifecycleState
 
 internal fun List<LifecycleState>.combine(): LifecycleState {
     val shouldStop = any { it == LifecycleState.Stopped }
-    if (shouldStop) {
-        return LifecycleState.Stopped
+    val completed = any { it == LifecycleState.Completed }
+
+    return when {
+        shouldStop -> LifecycleState.Stopped
+        completed -> LifecycleState.Completed
+        else -> LifecycleState.Started
     }
-    return LifecycleState.Started
 }


### PR DESCRIPTION
If we setup Scarlet with lifecycleOwner from Activity or Fragment then when onDestroy them Lifecycle's Scarlet will still retry again. 


```
val configuration = Scarlet.Configuration(
                lifecycle = AndroidLifecycle.ofLifecycleOwnerForeground(application, **this**),
                messageAdapterFactories = listOf(ProtobufMessageAdapter.Factory(registry)),
                streamAdapterFactories = listOf(RxJava2StreamAdapterFactory())
        )
```

After debug I found this issue by the extension function List<LifecycleState>.combine(). In this only check and return Started or Stopped. If in list contains any state = Completed, it must have return Completed to Scarlet know observeWebSocketEvent which registed was completed.
    
```
fun List<LifecycleState>.combine(): LifecycleState {
    val shouldStop = any { it == LifecycleState.Stopped }
    val completed = any { it == LifecycleState.Completed }

    return when {
        shouldStop -> LifecycleState.Stopped
        completed -> LifecycleState.Completed
        else -> LifecycleState.Started
    }
}
```