### PR TITLE
Do not use the registry as param if it is null

### DIFF
--- a/scarlet-message-adapter-protobuf/src/main/java/com/tinder/scarlet/messageadapter/protobuf/ProtobufMessageAdapter.kt
+++ b/scarlet-message-adapter-protobuf/src/main/java/com/tinder/scarlet/messageadapter/protobuf/ProtobufMessageAdapter.kt
@@ -27,7 +27,10 @@ class ProtobufMessageAdapter<T : MessageLite> private constructor(
             is Message.Bytes -> message.value
         }
         try {
-            return parser.parseFrom(bytesValue, registry)
+            return when (registry) {
+                null -> parser.parseFrom(bytesValue)
+                else -> parser.parseFrom(bytesValue, registry)
+            }
         } catch (e: InvalidProtocolBufferException) {
             throw RuntimeException(e) // Despite extending IOException, this is data mismatch.
         }


### PR DESCRIPTION
When using ProtobufMessageAdapter.Factory() without an extension registry the ProtobufMessageAdapter fails when invoking parser.parseFrom(bytesValue, registry) with a null registry.

I simple propose a check on registry and use parser.parseFrom(bytesValue, registry) or parser.parseFrom(bytesValue) accordingly

Tested with protobuf-java 3.9.0