### PR TITLE
Added ServiceStartedLifecycle to work with a Service owned Lifecycle

### DIFF
--- a/scarlet-lifecycle-android/src/main/java/com/tinder/scarlet/lifecycle/android/AndroidLifecycle.kt
+++ b/scarlet-lifecycle-android/src/main/java/com/tinder/scarlet/lifecycle/android/AndroidLifecycle.kt
@@ -31,4 +31,14 @@ object AndroidLifecycle {
     ): Lifecycle =
         LifecycleOwnerResumedLifecycle(lifecycleOwner, LifecycleRegistry(throttleTimeoutMillis))
             .combineWith(ConnectivityOnLifecycle(application))
+
+    @JvmStatic
+    @JvmOverloads
+    fun ofServiceStarted(
+        application: Application,
+        lifecycleOwner: LifecycleOwner,
+        throttleTimeoutMillis: Long = ACTIVITY_THROTTLE_TIMEOUT_MILLIS
+    ): Lifecycle =
+        ServiceStartedLifecycle(lifecycleOwner, LifecycleRegistry(throttleTimeoutMillis))
+            .combineWith(ConnectivityOnLifecycle(application))
 }

--- a/scarlet-lifecycle-android/src/main/java/com/tinder/scarlet/lifecycle/android/ServiceStartedLifecycle.kt
+++ b/scarlet-lifecycle-android/src/main/java/com/tinder/scarlet/lifecycle/android/ServiceStartedLifecycle.kt
@@ -1,0 +1,34 @@
+/*
+ * © 2018 Match Group, LLC.
+ */
+
+package com.tinder.scarlet.lifecycle.android
+
+import androidx.lifecycle.LifecycleObserver
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.OnLifecycleEvent
+import com.tinder.scarlet.Lifecycle
+import com.tinder.scarlet.lifecycle.LifecycleRegistry
+
+internal class ServiceStartedLifecycle(
+    private val lifecycleOwner: LifecycleOwner,
+    private val lifecycleRegistry: LifecycleRegistry
+) : Lifecycle by lifecycleRegistry {
+
+    init {
+        lifecycleOwner.lifecycle.addObserver(ALifecycleObserver())
+    }
+
+    private inner class ALifecycleObserver : LifecycleObserver {
+        @OnLifecycleEvent(androidx.lifecycle.Lifecycle.Event.ON_START)
+        fun onResume() = lifecycleRegistry.onNext(Lifecycle.State.Started)
+
+        @OnLifecycleEvent(androidx.lifecycle.Lifecycle.Event.ON_STOP)
+        fun onStop() = lifecycleRegistry.onNext(Lifecycle.State.Stopped.AndAborted)
+
+        @OnLifecycleEvent(androidx.lifecycle.Lifecycle.Event.ON_DESTROY)
+        fun onDestroy() {
+            lifecycleRegistry.onComplete()
+        }
+    }
+}


### PR DESCRIPTION
It may be useful to have a scarlet lifecycle related to Service. Because Service and Activity have different lifecycles it is needed a lifecycle that starts on Lifecycle.Event.ON_START instead of Lifecycle.Event.ON_RESUME.