### PR TITLE
Add cleartext traffic check

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -5,8 +5,6 @@ ext.versions = [
     compileSdkVersion: 28,
     buildToolsVersion: "28.0.3",
 
-    android: '9-robolectric-4913185-2',
-
     appCompat: '1.0.0',
     material: '1.0.0',
     multiDex: '2.0.0',
@@ -53,7 +51,7 @@ ext.versions = [
 ]
 
 ext.libs = [
-    android: "org.robolectric:android-all:$versions.android",
+    android: "org.robolectric:android-all:10-robolectric-5803371",
 
     appCompat: "androidx.appcompat:appcompat:$versions.appCompat",
     material: "com.google.android.material:material:$versions.material",

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -5,6 +5,8 @@ ext {
     compileSdkVersion = 28
     buildToolsVersion = '28.0.3'
 
+    android = 'org.robolectric:android-all:9-robolectric-4913185-2'
+
     appCompat = 'androidx.appcompat:appcompat:1.0.0'
     material = 'com.google.android.material:material:1.0.0'
     multiDex = 'androidx.multidex:multidex:2.0.0'

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -53,7 +53,7 @@ ext.versions = [
 ]
 
 ext.libs = [
-    android = "org.robolectric:android-all:$versions.android",
+    android: "org.robolectric:android-all:$versions.android",
 
     appCompat: "androidx.appcompat:appcompat:$versions.appCompat",
     material: "com.google.android.material:material:$versions.material",

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -5,7 +5,7 @@ ext.versions = [
     compileSdkVersion: 28,
     buildToolsVersion: "28.0.3",
 
-    android = 'org.robolectric:android-all:9-robolectric-4913185-2',
+    android: '9-robolectric-4913185-2',
 
     appCompat: '1.0.0',
     material: '1.0.0',
@@ -53,6 +53,8 @@ ext.versions = [
 ]
 
 ext.libs = [
+    android = "org.robolectric:android-all:$versions.android",
+
     appCompat: "androidx.appcompat:appcompat:$versions.appCompat",
     material: "com.google.android.material:material:$versions.material",
     multiDex: "androidx.multidex:multidex:$versions.multiDex",

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -5,7 +5,7 @@ ext.versions = [
     compileSdkVersion: 28,
     buildToolsVersion: "28.0.3",
 
-    android = 'org.robolectric:android-all:9-robolectric-4913185-2'
+    android = 'org.robolectric:android-all:9-robolectric-4913185-2',
 
     appCompat: '1.0.0',
     material: '1.0.0',

--- a/scarlet-websocket-okhttp/build.gradle
+++ b/scarlet-websocket-okhttp/build.gradle
@@ -9,6 +9,7 @@ dependencies {
     implementation project(':scarlet-core-internal')
     implementation rootProject.ext.rxJava
     implementation rootProject.ext.kotlinStdlib
+    compileOnly "org.robolectric:android-all:9-robolectric-4913185-2"
 
     testImplementation project(':scarlet')
     testImplementation project(':scarlet-websocket-mockwebserver')

--- a/scarlet-websocket-okhttp/build.gradle
+++ b/scarlet-websocket-okhttp/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     implementation project(':scarlet-core-internal')
     implementation libs.rxJava
     implementation libs.kotlin.stdlib
-    compileOnly rootProject.ext.android
+    compileOnly libs.android
 
     testImplementation project(':scarlet')
     testImplementation project(':scarlet-websocket-mockwebserver')

--- a/scarlet-websocket-okhttp/build.gradle
+++ b/scarlet-websocket-okhttp/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     implementation project(':scarlet-core-internal')
     implementation rootProject.ext.rxJava
     implementation rootProject.ext.kotlinStdlib
-    compileOnly "org.robolectric:android-all:9-robolectric-4913185-2"
+    compileOnly rootProject.ext.android
 
     testImplementation project(':scarlet')
     testImplementation project(':scarlet-websocket-mockwebserver')

--- a/scarlet-websocket-okhttp/src/main/java/com/tinder/scarlet/websocket/okhttp/OkHttpClientUtils.kt
+++ b/scarlet-websocket-okhttp/src/main/java/com/tinder/scarlet/websocket/okhttp/OkHttpClientUtils.kt
@@ -11,8 +11,8 @@ import android.security.NetworkSecurityPolicy
 import com.tinder.scarlet.WebSocket
 import com.tinder.scarlet.websocket.okhttp.request.RequestFactory
 import com.tinder.scarlet.websocket.okhttp.request.StaticUrlRequestFactory
+import okhttp3.HttpUrl
 import okhttp3.OkHttpClient
-import java.net.URL
 import java.net.UnknownServiceException
 
 fun OkHttpClient.newWebSocketFactory(requestFactory: RequestFactory): WebSocket.Factory {
@@ -24,7 +24,7 @@ fun OkHttpClient.newWebSocketFactory(url: String): WebSocket.Factory {
         try {
             if ((Build.VERSION.SDK_INT > 23 &&
                             !NetworkSecurityPolicy.getInstance().isCleartextTrafficPermitted(
-                                    URL("http:${url.substring(3)}").host)) ||
+                                    HttpUrl.parse("http:${url.substring(3)}")?.host())) ||
                     (Build.VERSION.SDK_INT == 23 &&
                             !NetworkSecurityPolicy.getInstance().isCleartextTrafficPermitted)) {
                 throw UnknownServiceException(

--- a/scarlet-websocket-okhttp/src/main/java/com/tinder/scarlet/websocket/okhttp/OkHttpClientUtils.kt
+++ b/scarlet-websocket-okhttp/src/main/java/com/tinder/scarlet/websocket/okhttp/OkHttpClientUtils.kt
@@ -6,6 +6,8 @@
 
 package com.tinder.scarlet.websocket.okhttp
 
+import android.os.Build
+import android.security.NetworkSecurityPolicy
 import com.tinder.scarlet.WebSocket
 import com.tinder.scarlet.websocket.okhttp.request.RequestFactory
 import com.tinder.scarlet.websocket.okhttp.request.StaticUrlRequestFactory
@@ -18,7 +20,7 @@ fun OkHttpClient.newWebSocketFactory(requestFactory: RequestFactory): WebSocket.
 fun OkHttpClient.newWebSocketFactory(url: String): WebSocket.Factory {
     if (url.startsWith("ws://")) {
         try {
-            if (android.os.Build.VERSION.SDK_INT >= 23 &&
+            if (Build.VERSION.SDK_INT >= 23 &&
                     !NetworkSecurityPolicy.getInstance().isCleartextTrafficPermitted()) {
                 throw RuntimeException("Android configuration does not permit cleartext traffic.")
             }

--- a/scarlet-websocket-okhttp/src/main/java/com/tinder/scarlet/websocket/okhttp/OkHttpClientUtils.kt
+++ b/scarlet-websocket-okhttp/src/main/java/com/tinder/scarlet/websocket/okhttp/OkHttpClientUtils.kt
@@ -19,7 +19,7 @@ fun OkHttpClient.newWebSocketFactory(requestFactory: RequestFactory): WebSocket.
 }
 
 fun OkHttpClient.newWebSocketFactory(url: String): WebSocket.Factory {
-    if (url.startsWith("ws://", ignoreCase = true)) {
+    if (url.startsWith("ws:", ignoreCase = true)) {
         try {
             if ((Build.VERSION.SDK_INT == 23 &&
                             !NetworkSecurityPolicy.getInstance().isCleartextTrafficPermitted)

--- a/scarlet-websocket-okhttp/src/main/java/com/tinder/scarlet/websocket/okhttp/OkHttpClientUtils.kt
+++ b/scarlet-websocket-okhttp/src/main/java/com/tinder/scarlet/websocket/okhttp/OkHttpClientUtils.kt
@@ -24,7 +24,7 @@ fun OkHttpClient.newWebSocketFactory(url: String): WebSocket.Factory {
         try {
             if ((Build.VERSION.SDK_INT > 23 &&
                             !NetworkSecurityPolicy.getInstance().isCleartextTrafficPermitted(
-                                    URL(url).host)) ||
+                                    URL("http:${url.substring(3)}").host)) ||
                     (Build.VERSION.SDK_INT == 23 &&
                             !NetworkSecurityPolicy.getInstance().isCleartextTrafficPermitted)) {
                 throw UnknownServiceException(

--- a/scarlet-websocket-okhttp/src/main/java/com/tinder/scarlet/websocket/okhttp/OkHttpClientUtils.kt
+++ b/scarlet-websocket-okhttp/src/main/java/com/tinder/scarlet/websocket/okhttp/OkHttpClientUtils.kt
@@ -10,7 +10,6 @@ import com.tinder.scarlet.WebSocket
 import com.tinder.scarlet.websocket.okhttp.request.RequestFactory
 import com.tinder.scarlet.websocket.okhttp.request.StaticUrlRequestFactory
 import okhttp3.OkHttpClient
-import java.lang.RuntimeException
 
 fun OkHttpClient.newWebSocketFactory(requestFactory: RequestFactory): WebSocket.Factory {
     return OkHttpWebSocket.Factory(OkHttpClientWebSocketConnectionEstablisher(this, requestFactory))

--- a/scarlet-websocket-okhttp/src/main/java/com/tinder/scarlet/websocket/okhttp/OkHttpClientUtils.kt
+++ b/scarlet-websocket-okhttp/src/main/java/com/tinder/scarlet/websocket/okhttp/OkHttpClientUtils.kt
@@ -10,11 +10,23 @@ import com.tinder.scarlet.WebSocket
 import com.tinder.scarlet.websocket.okhttp.request.RequestFactory
 import com.tinder.scarlet.websocket.okhttp.request.StaticUrlRequestFactory
 import okhttp3.OkHttpClient
+import java.lang.RuntimeException
 
 fun OkHttpClient.newWebSocketFactory(requestFactory: RequestFactory): WebSocket.Factory {
     return OkHttpWebSocket.Factory(OkHttpClientWebSocketConnectionEstablisher(this, requestFactory))
 }
 
 fun OkHttpClient.newWebSocketFactory(url: String): WebSocket.Factory {
+    if (url.startsWith("ws://")) {
+        try {
+            if (android.os.Build.VERSION.SDK_INT >= 23 &&
+                    !NetworkSecurityPolicy.getInstance().isCleartextTrafficPermitted()) {
+                throw RuntimeException("Android configuration does not permit cleartext traffic.")
+            }
+        } catch (_: ClassNotFoundException) {
+            // Not running on Android
+        }
+    }
+
     return newWebSocketFactory(StaticUrlRequestFactory(url))
 }

--- a/scarlet-websocket-okhttp/src/main/java/com/tinder/scarlet/websocket/okhttp/OkHttpClientUtils.kt
+++ b/scarlet-websocket-okhttp/src/main/java/com/tinder/scarlet/websocket/okhttp/OkHttpClientUtils.kt
@@ -12,6 +12,7 @@ import com.tinder.scarlet.WebSocket
 import com.tinder.scarlet.websocket.okhttp.request.RequestFactory
 import com.tinder.scarlet.websocket.okhttp.request.StaticUrlRequestFactory
 import okhttp3.OkHttpClient
+import java.net.URL
 import java.net.UnknownServiceException
 
 fun OkHttpClient.newWebSocketFactory(requestFactory: RequestFactory): WebSocket.Factory {
@@ -21,11 +22,11 @@ fun OkHttpClient.newWebSocketFactory(requestFactory: RequestFactory): WebSocket.
 fun OkHttpClient.newWebSocketFactory(url: String): WebSocket.Factory {
     if (url.startsWith("ws:", ignoreCase = true)) {
         try {
-            if ((Build.VERSION.SDK_INT == 23 &&
-                            !NetworkSecurityPolicy.getInstance().isCleartextTrafficPermitted)
-                    || (Build.VERSION.SDK_INT > 23 &&
+            if ((Build.VERSION.SDK_INT > 23 &&
                             !NetworkSecurityPolicy.getInstance().isCleartextTrafficPermitted(
-                                    url))) {
+                                    URL(url).host)) ||
+                    (Build.VERSION.SDK_INT == 23 &&
+                            !NetworkSecurityPolicy.getInstance().isCleartextTrafficPermitted)) {
                 throw UnknownServiceException(
                         "CLEARTEXT communication to $url not permitted by network security policy")
             }


### PR DESCRIPTION
When someone tries to open a Websocket connection without using TLS (ie "ws:" instead of "wss:") on Android 9 and newer, the connection will fail and Scarlet will not provide any information about this to the developer. This confused me as well as the author of [this](https://stackoverflow.com/q/57675908/859277) post. 

Okhttp has a similar check [here](https://github.com/square/okhttp/blob/7a641531c8e03b10dc4fbf9f2465775d7ecc7649/okhttp/src/main/java/okhttp3/internal/connection/RealConnection.kt#L160). 

I check for a ClassNotFoundException, so it should not cause any issues for non-Android apps that use Scarlet.