### PR TITLE
Remove Started default in AppResumedLifecycle

### DIFF
--- a/scarlet-lifecycle-android/src/main/java/com/tinder/scarlet/lifecycle/android/ApplicationResumedLifecycle.kt
+++ b/scarlet-lifecycle-android/src/main/java/com/tinder/scarlet/lifecycle/android/ApplicationResumedLifecycle.kt
@@ -17,7 +17,6 @@ internal class ApplicationResumedLifecycle(
 ) : Lifecycle by lifecycleRegistry {
 
     init {
-        lifecycleRegistry.onNext(Lifecycle.State.Started)
         application.registerActivityLifecycleCallbacks(ActivityLifecycleCallbacks())
     }
 


### PR DESCRIPTION
This can result in assuming the app is visible when the app is created without
being brought into the foreground. e.g. when receiving notifications.

Co-authored-by: Siggi Jonsson <siggijons@siggijons.net>