### PR TITLE
JDK 11 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/android:api-28-alpha
+      - image: circleci/android:api-30
     environment:
         TERM: dumb
         JAVA_TOOL_OPTIONS: "-Xmx1g"

--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,10 @@ subprojects { project ->
             jvmTarget = "1.8"
         }
     }
+    tasks.withType(JavaCompile).configureEach {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
 }
 
 apply from: rootProject.file('dependencies.gradle')

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -44,7 +44,6 @@ ext.versions = [
     okSse: '0.9.0',
 
     junit: '4.12',
-    mockito: '1.6.0',
     assertJ: '3.8.0',
 
     stateMachine: "0.2.0"
@@ -102,7 +101,7 @@ ext.libs = [
     okSse: "com.github.heremaps:oksse:$versions.okSse",
 
     junit: "junit:junit:$versions.junit",
-    mockito: "com.nhaarman:mockito-kotlin-kt1.1:$versions.mockito",
+    mockito: "com.nhaarman.mockitokotlin2:mockito-kotlin:2.2.0",
     assertJ: "org.assertj:assertj-core:$versions.assertJ",
 
     kotlin: [

--- a/scarlet-stream-adapter-builtin/src/test/java/com/tinder/scarlet/streamadapter/builtin/IdentityStreamAdapterTest.kt
+++ b/scarlet-stream-adapter-builtin/src/test/java/com/tinder/scarlet/streamadapter/builtin/IdentityStreamAdapterTest.kt
@@ -4,7 +4,7 @@
 
 package com.tinder.scarlet.streamadapter.builtin
 
-import com.nhaarman.mockito_kotlin.mock
+import com.nhaarman.mockitokotlin2.mock
 import com.tinder.scarlet.Stream
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test

--- a/scarlet-websocket-okhttp/src/test/java/com/tinder/scarlet/websocket/okhttp/OkHttpWebSocketEventObserverTest.kt
+++ b/scarlet-websocket-okhttp/src/test/java/com/tinder/scarlet/websocket/okhttp/OkHttpWebSocketEventObserverTest.kt
@@ -4,7 +4,7 @@
 
 package com.tinder.scarlet.websocket.okhttp
 
-import com.nhaarman.mockito_kotlin.mock
+import com.nhaarman.mockitokotlin2.mock
 import com.tinder.scarlet.Message
 import com.tinder.scarlet.ShutdownReason
 import com.tinder.scarlet.WebSocket

--- a/scarlet-websocket-okhttp/src/test/java/com/tinder/scarlet/websocket/okhttp/OkHttpWebSocketHolderTest.kt
+++ b/scarlet-websocket-okhttp/src/test/java/com/tinder/scarlet/websocket/okhttp/OkHttpWebSocketHolderTest.kt
@@ -4,10 +4,10 @@
 
 package com.tinder.scarlet.websocket.okhttp
 
-import com.nhaarman.mockito_kotlin.any
-import com.nhaarman.mockito_kotlin.doReturn
-import com.nhaarman.mockito_kotlin.mock
-import com.nhaarman.mockito_kotlin.then
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.doReturn
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.then
 import okhttp3.WebSocket
 import okio.ByteString
 import org.assertj.core.api.Assertions.assertThat

--- a/scarlet-websocket-okhttp/src/test/java/com/tinder/scarlet/websocket/okhttp/OkHttpWebSocketTest.kt
+++ b/scarlet-websocket-okhttp/src/test/java/com/tinder/scarlet/websocket/okhttp/OkHttpWebSocketTest.kt
@@ -4,10 +4,10 @@
 
 package com.tinder.scarlet.websocket.okhttp
 
-import com.nhaarman.mockito_kotlin.any
-import com.nhaarman.mockito_kotlin.doReturn
-import com.nhaarman.mockito_kotlin.mock
-import com.nhaarman.mockito_kotlin.then
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.doReturn
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.then
 import com.tinder.scarlet.WebSocket.Event
 import com.tinder.scarlet.Message
 import com.tinder.scarlet.ShutdownReason

--- a/scarlet/src/test/java/com/tinder/scarlet/ScarletTest.kt
+++ b/scarlet/src/test/java/com/tinder/scarlet/ScarletTest.kt
@@ -4,10 +4,10 @@
 
 package com.tinder.scarlet
 
-import com.nhaarman.mockito_kotlin.eq
-import com.nhaarman.mockito_kotlin.given
-import com.nhaarman.mockito_kotlin.mock
-import com.nhaarman.mockito_kotlin.then
+import com.nhaarman.mockitokotlin2.eq
+import com.nhaarman.mockitokotlin2.given
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.then
 import com.tinder.scarlet.internal.Service
 import com.tinder.scarlet.internal.utils.RuntimePlatform
 import com.tinder.scarlet.ws.Receive

--- a/scarlet/src/test/java/com/tinder/scarlet/internal/ServiceFactoryTest.kt
+++ b/scarlet/src/test/java/com/tinder/scarlet/internal/ServiceFactoryTest.kt
@@ -4,7 +4,7 @@
 
 package com.tinder.scarlet.internal
 
-import com.nhaarman.mockito_kotlin.mock
+import com.nhaarman.mockitokotlin2.mock
 import com.tinder.scarlet.internal.connection.Connection
 import com.tinder.scarlet.internal.servicemethod.ServiceMethodExecutor
 import com.tinder.scarlet.ws.Send

--- a/scarlet/src/test/java/com/tinder/scarlet/internal/ServiceTest.kt
+++ b/scarlet/src/test/java/com/tinder/scarlet/internal/ServiceTest.kt
@@ -4,8 +4,8 @@
 
 package com.tinder.scarlet.internal
 
-import com.nhaarman.mockito_kotlin.mock
-import com.nhaarman.mockito_kotlin.then
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.then
 import com.tinder.scarlet.internal.connection.Connection
 import com.tinder.scarlet.internal.servicemethod.ServiceMethodExecutor
 import org.junit.Test

--- a/scarlet/src/test/java/com/tinder/scarlet/internal/connection/ConnectionFactoryTest.kt
+++ b/scarlet/src/test/java/com/tinder/scarlet/internal/connection/ConnectionFactoryTest.kt
@@ -4,7 +4,7 @@
 
 package com.tinder.scarlet.internal.connection
 
-import com.nhaarman.mockito_kotlin.mock
+import com.nhaarman.mockitokotlin2.mock
 import com.tinder.scarlet.Lifecycle
 import com.tinder.scarlet.WebSocket
 import com.tinder.scarlet.retry.BackoffStrategy

--- a/scarlet/src/test/java/com/tinder/scarlet/internal/connection/ConnectionStateManagerTest.kt
+++ b/scarlet/src/test/java/com/tinder/scarlet/internal/connection/ConnectionStateManagerTest.kt
@@ -4,9 +4,9 @@
 
 package com.tinder.scarlet.internal.connection
 
-import com.nhaarman.mockito_kotlin.given
-import com.nhaarman.mockito_kotlin.mock
-import com.nhaarman.mockito_kotlin.then
+import com.nhaarman.mockitokotlin2.given
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.then
 import com.tinder.scarlet.Event
 import com.tinder.scarlet.Lifecycle
 import com.tinder.scarlet.ShutdownReason
@@ -241,7 +241,7 @@ internal class ConnectionStateManagerTest {
                         .subscribe(processor!!::onNext)
                     processor!!.doOnSubscribe { subscriptionCount += 1 }.toStream()
                 }
-                given(close(com.nhaarman.mockito_kotlin.any())).willAnswer {
+                given(close(com.nhaarman.mockitokotlin2.any())).willAnswer {
                     Flowable.empty<WebSocket.Event>()
                         .delay(delayMillis, TimeUnit.MILLISECONDS, scheduler)
                         .subscribe(processor!!)

--- a/scarlet/src/test/java/com/tinder/scarlet/internal/connection/ConnectionTest.kt
+++ b/scarlet/src/test/java/com/tinder/scarlet/internal/connection/ConnectionTest.kt
@@ -4,9 +4,9 @@
 
 package com.tinder.scarlet.internal.connection
 
-import com.nhaarman.mockito_kotlin.given
-import com.nhaarman.mockito_kotlin.mock
-import com.nhaarman.mockito_kotlin.then
+import com.nhaarman.mockitokotlin2.given
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.then
 import com.tinder.scarlet.Event
 import com.tinder.scarlet.Message
 import com.tinder.scarlet.Session

--- a/scarlet/src/test/java/com/tinder/scarlet/internal/connection/LifecycleStateSubscriberTest.kt
+++ b/scarlet/src/test/java/com/tinder/scarlet/internal/connection/LifecycleStateSubscriberTest.kt
@@ -4,10 +4,10 @@
 
 package com.tinder.scarlet.internal.connection
 
-import com.nhaarman.mockito_kotlin.argThat
-import com.nhaarman.mockito_kotlin.mock
-import com.nhaarman.mockito_kotlin.then
-import com.nhaarman.mockito_kotlin.times
+import com.nhaarman.mockitokotlin2.argThat
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.then
+import com.nhaarman.mockitokotlin2.times
 import com.tinder.scarlet.Event
 import com.tinder.scarlet.Lifecycle
 import com.tinder.scarlet.internal.connection.subscriber.LifecycleStateSubscriber

--- a/scarlet/src/test/java/com/tinder/scarlet/internal/connection/RetryTimerSubscriberTest.kt
+++ b/scarlet/src/test/java/com/tinder/scarlet/internal/connection/RetryTimerSubscriberTest.kt
@@ -4,8 +4,8 @@
 
 package com.tinder.scarlet.internal.connection
 
-import com.nhaarman.mockito_kotlin.mock
-import com.nhaarman.mockito_kotlin.then
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.then
 import com.tinder.scarlet.Event
 import com.tinder.scarlet.internal.connection.subscriber.RetryTimerSubscriber
 import io.reactivex.Flowable

--- a/scarlet/src/test/java/com/tinder/scarlet/internal/connection/WebSocketEventSubscriberTest.kt
+++ b/scarlet/src/test/java/com/tinder/scarlet/internal/connection/WebSocketEventSubscriberTest.kt
@@ -4,9 +4,9 @@
 
 package com.tinder.scarlet.internal.connection
 
-import com.nhaarman.mockito_kotlin.argThat
-import com.nhaarman.mockito_kotlin.mock
-import com.nhaarman.mockito_kotlin.then
+import com.nhaarman.mockitokotlin2.argThat
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.then
 import com.tinder.scarlet.Event
 import com.tinder.scarlet.WebSocket
 import com.tinder.scarlet.internal.connection.subscriber.WebSocketEventSubscriber

--- a/scarlet/src/test/java/com/tinder/scarlet/internal/servicemethod/EventMapperFactoryTest.kt
+++ b/scarlet/src/test/java/com/tinder/scarlet/internal/servicemethod/EventMapperFactoryTest.kt
@@ -4,8 +4,8 @@
 
 package com.tinder.scarlet.internal.servicemethod
 
-import com.nhaarman.mockito_kotlin.given
-import com.nhaarman.mockito_kotlin.mock
+import com.nhaarman.mockitokotlin2.given
+import com.nhaarman.mockitokotlin2.mock
 import com.tinder.scarlet.Deserialization
 import com.tinder.scarlet.Event
 import com.tinder.scarlet.Lifecycle

--- a/scarlet/src/test/java/com/tinder/scarlet/internal/servicemethod/EventMapperTest.kt
+++ b/scarlet/src/test/java/com/tinder/scarlet/internal/servicemethod/EventMapperTest.kt
@@ -4,8 +4,8 @@
 
 package com.tinder.scarlet.internal.servicemethod
 
-import com.nhaarman.mockito_kotlin.given
-import com.nhaarman.mockito_kotlin.mock
+import com.nhaarman.mockitokotlin2.given
+import com.nhaarman.mockitokotlin2.mock
 import com.tinder.scarlet.Deserialization
 import com.tinder.scarlet.Event
 import com.tinder.scarlet.Lifecycle

--- a/scarlet/src/test/java/com/tinder/scarlet/internal/servicemethod/MessageAdapterResolverTest.kt
+++ b/scarlet/src/test/java/com/tinder/scarlet/internal/servicemethod/MessageAdapterResolverTest.kt
@@ -4,8 +4,8 @@
 
 package com.tinder.scarlet.internal.servicemethod
 
-import com.nhaarman.mockito_kotlin.given
-import com.nhaarman.mockito_kotlin.mock
+import com.nhaarman.mockitokotlin2.given
+import com.nhaarman.mockitokotlin2.mock
 import com.tinder.scarlet.MessageAdapter
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatIllegalStateException

--- a/scarlet/src/test/java/com/tinder/scarlet/internal/servicemethod/ReceiveServiceMethodFactoryTest.kt
+++ b/scarlet/src/test/java/com/tinder/scarlet/internal/servicemethod/ReceiveServiceMethodFactoryTest.kt
@@ -4,11 +4,11 @@
 
 package com.tinder.scarlet.internal.servicemethod
 
-import com.nhaarman.mockito_kotlin.any
-import com.nhaarman.mockito_kotlin.anyArray
-import com.nhaarman.mockito_kotlin.given
-import com.nhaarman.mockito_kotlin.mock
-import com.nhaarman.mockito_kotlin.then
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.anyArray
+import com.nhaarman.mockitokotlin2.given
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.then
 import com.tinder.scarlet.Deserialization
 import com.tinder.scarlet.Stream
 import com.tinder.scarlet.StreamAdapter

--- a/scarlet/src/test/java/com/tinder/scarlet/internal/servicemethod/ReceiveServiceMethodTest.kt
+++ b/scarlet/src/test/java/com/tinder/scarlet/internal/servicemethod/ReceiveServiceMethodTest.kt
@@ -4,12 +4,12 @@
 
 package com.tinder.scarlet.internal.servicemethod
 
-import com.nhaarman.mockito_kotlin.any
-import com.nhaarman.mockito_kotlin.given
-import com.nhaarman.mockito_kotlin.mock
-import com.nhaarman.mockito_kotlin.never
-import com.nhaarman.mockito_kotlin.only
-import com.nhaarman.mockito_kotlin.then
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.given
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.never
+import com.nhaarman.mockitokotlin2.only
+import com.nhaarman.mockitokotlin2.then
 import com.tinder.scarlet.Event
 import com.tinder.scarlet.internal.connection.Connection
 import com.tinder.scarlet.streamadapter.rxjava2.FlowableStreamAdapter

--- a/scarlet/src/test/java/com/tinder/scarlet/internal/servicemethod/SendServiceMethodFactoryTest.kt
+++ b/scarlet/src/test/java/com/tinder/scarlet/internal/servicemethod/SendServiceMethodFactoryTest.kt
@@ -4,11 +4,11 @@
 
 package com.tinder.scarlet.internal.servicemethod
 
-import com.nhaarman.mockito_kotlin.any
-import com.nhaarman.mockito_kotlin.eq
-import com.nhaarman.mockito_kotlin.given
-import com.nhaarman.mockito_kotlin.mock
-import com.nhaarman.mockito_kotlin.then
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.eq
+import com.nhaarman.mockitokotlin2.given
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.then
 import com.tinder.scarlet.MessageAdapter
 import com.tinder.scarlet.internal.connection.Connection
 import com.tinder.scarlet.utils.onlyMethod

--- a/scarlet/src/test/java/com/tinder/scarlet/internal/servicemethod/SendServiceMethodTest.kt
+++ b/scarlet/src/test/java/com/tinder/scarlet/internal/servicemethod/SendServiceMethodTest.kt
@@ -4,10 +4,10 @@
 
 package com.tinder.scarlet.internal.servicemethod
 
-import com.nhaarman.mockito_kotlin.given
-import com.nhaarman.mockito_kotlin.mock
-import com.nhaarman.mockito_kotlin.only
-import com.nhaarman.mockito_kotlin.then
+import com.nhaarman.mockitokotlin2.given
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.only
+import com.nhaarman.mockitokotlin2.then
 import com.tinder.scarlet.Message
 import com.tinder.scarlet.MessageAdapter
 import com.tinder.scarlet.internal.connection.Connection

--- a/scarlet/src/test/java/com/tinder/scarlet/internal/servicemethod/ServiceMethodExecutorFactoryTest.kt
+++ b/scarlet/src/test/java/com/tinder/scarlet/internal/servicemethod/ServiceMethodExecutorFactoryTest.kt
@@ -4,10 +4,10 @@
 
 package com.tinder.scarlet.internal.servicemethod
 
-import com.nhaarman.mockito_kotlin.any
-import com.nhaarman.mockito_kotlin.eq
-import com.nhaarman.mockito_kotlin.given
-import com.nhaarman.mockito_kotlin.mock
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.eq
+import com.nhaarman.mockitokotlin2.given
+import com.nhaarman.mockitokotlin2.mock
 import com.tinder.scarlet.Stream
 import com.tinder.scarlet.internal.connection.Connection
 import com.tinder.scarlet.internal.utils.RuntimePlatform

--- a/scarlet/src/test/java/com/tinder/scarlet/internal/servicemethod/ServiceMethodExecutorTest.kt
+++ b/scarlet/src/test/java/com/tinder/scarlet/internal/servicemethod/ServiceMethodExecutorTest.kt
@@ -4,8 +4,8 @@
 
 package com.tinder.scarlet.internal.servicemethod
 
-import com.nhaarman.mockito_kotlin.mock
-import com.nhaarman.mockito_kotlin.then
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.then
 import org.assertj.core.api.Assertions.assertThatIllegalStateException
 import org.junit.Test
 import org.junit.runner.RunWith

--- a/scarlet/src/test/java/com/tinder/scarlet/internal/servicemethod/StreamAdapterResolverTest.kt
+++ b/scarlet/src/test/java/com/tinder/scarlet/internal/servicemethod/StreamAdapterResolverTest.kt
@@ -4,8 +4,8 @@
 
 package com.tinder.scarlet.internal.servicemethod
 
-import com.nhaarman.mockito_kotlin.given
-import com.nhaarman.mockito_kotlin.mock
+import com.nhaarman.mockitokotlin2.given
+import com.nhaarman.mockitokotlin2.mock
 import com.tinder.scarlet.StreamAdapter
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatIllegalStateException

--- a/scarlet/src/test/java/com/tinder/scarlet/retry/ExponentialBackoffWithJitterBackoffStrategyTest.kt
+++ b/scarlet/src/test/java/com/tinder/scarlet/retry/ExponentialBackoffWithJitterBackoffStrategyTest.kt
@@ -4,9 +4,9 @@
 
 package com.tinder.scarlet.retry
 
-import com.nhaarman.mockito_kotlin.any
-import com.nhaarman.mockito_kotlin.doAnswer
-import com.nhaarman.mockito_kotlin.mock
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.doAnswer
+import com.nhaarman.mockitokotlin2.mock
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatExceptionOfType
 import org.junit.Test


### PR DESCRIPTION
* Updated mockito kotlin to 2.2.0 whose transitive dependency of Mockito 2.30.0 has JDK 11 support.
* Make sure projects produce JDK 8 compatible bytecode.
* Also an attempt to unblock https://github.com/Tinder/Scarlet/pull/170