### PR TITLE
Fixes #204, after updating all the tool chain, the task name was updated

### DIFF
--- a/publish.sh
+++ b/publish.sh
@@ -16,6 +16,6 @@ elif [ "${CIRCLE_BRANCH}" != "$BRANCH" ]; then
   echo "Skipping snapshot deployment: wrong branch. Expected '$BRANCH' but was '${CIRCLE_BRANCH}'."
 else
   echo "Deploying snapshot..."
-  ./gradlew clean uploadArchives
+  ./gradlew clean publish
   echo "Snapshot deployed!"
 fi


### PR DESCRIPTION
I saw the issue after the last few commits and realized updating the toolset breaks a bit of the publishing.