### PR TITLE
Attempts to fix #204 again, javadoc excluded

### DIFF
--- a/publish.sh
+++ b/publish.sh
@@ -16,6 +16,6 @@ elif [ "${CIRCLE_BRANCH}" != "$BRANCH" ]; then
   echo "Skipping snapshot deployment: wrong branch. Expected '$BRANCH' but was '${CIRCLE_BRANCH}'."
 else
   echo "Deploying snapshot..."
-  ./gradlew clean publish
+  ./gradlew -Dmaven.javadoc.skip=true clean publish
   echo "Snapshot deployed!"
 fi

--- a/scarlet-core/build.gradle
+++ b/scarlet-core/build.gradle
@@ -9,3 +9,7 @@ dependencies {
     testImplementation libs.junit
     testImplementation libs.assertJ
 }
+
+subprojects {
+    tasks.withType(Javadoc).all { enabled = false }
+}


### PR DESCRIPTION
One more time. The thought being that the only javadoc able file would be the internal Utils class. Which shouldn't be documented. Everything else should run through the dokka tasks